### PR TITLE
Stylistic changes to dabe_aw11.py that fix segfaults when using embedded Python

### DIFF
--- a/charm/schemes/dabe_aw11.py
+++ b/charm/schemes/dabe_aw11.py
@@ -101,6 +101,8 @@ class Dabe(ABEncMultiAuth):
             print("Key gen for %s on %s" % (gid, i))
             print("H(GID): '%s'" % h)
             print("K = g^alpha_i * H(GID) ^ y_i: %s" % K)
+        
+        return pkey[i]
 
     def encrypt(self, pk, gp, M, policy_str):
         '''Encrypt'''
@@ -141,7 +143,7 @@ class Dabe(ABEncMultiAuth):
         policy = util.createPolicy(ct['policy'])
         pruned = util.prune(policy, usr_attribs)
         if pruned == False:
-            return False        
+            raise Exception("Don't have the required attributes for decryption!")        
         coeffs = util.getCoefficients(policy)
     
         h_gid = gp['H'](sk['gid'])  #find H(GID)


### PR DESCRIPTION
This is in relation to the segfaults mentioned in issue #68. The use case involves dabe_aw11 being wrapped by dabenc_adapt_hybrid. 

The change to decrypt() fixes crash 1, as the exception can be caught and handled normally, and the boolean value False is not passed to the hash function. Stylistically, it seems better, as trying to do a decryption without appropriate attributes is an exceptional case. In either case, dabenc_adapt_hybrid would throw an exception if decrypt() returned False.

The change to keygen() is more stylistic and fixes an issue in our application. Note that dabenc_adapt_hybrid returns the value returned by keygen, but since dabe_aw11 does not return in keygen, None is returned. So if an application uses keygen and wants to use the resulting key, it has to do a dictionary lookup. This simplifies that use case.
