### PR TITLE
Changes on [CL03] 

### DIFF
--- a/charm/schemes/pksig/pksig_cl03.py
+++ b/charm/schemes/pksig/pksig_cl03.py
@@ -1,3 +1,17 @@
+'''
+ A Signature Scheme with Efficient Protocols
+ 
+| From: "J. Camenisch, A. Lysyanskaya."
+| Published in: 2003
+| Available from: http://cs.brown.edu/~anna/papers/camlys02b.pdf 
+| Notes: Schemes 2.2 (on page 4) and 4 (on page 8). 
+
+* type:           signature
+* setting:        integer groups 
+
+:Authors:    ?/Antonio de la Piedra
+:Date:       11/2013
+ '''
 from charm.toolbox.PKSig import PKSig
 from charm.core.math.integer import integer,isPrime,random,randomPrime,randomBits
 import hashlib
@@ -20,6 +34,20 @@ class Sig_CL03(PKSig):
     >>> msg = integer(SHA1(b'This is the message I want to hash.'))
     >>> signature = pksig.sign(public_key, secret_key, msg)
     >>> pksig.verify(public_key, msg, signature)
+    True
+    >>> g  = {}
+    >>> m = {}
+    >>> j = 16
+    >>> for i in range(1, j + 1): g[str(i)] = randomQR(public_key['N'])
+    >>> for i in range(1, j + 1): m[str(i)] = random(public_key['N'])
+    >>> Cx = 1 % public_key['N']
+    >>> for i in range(1, len(m) + 1): Cx = Cx*(g[str(i)] ** m[str(i)])
+    >>> pksig = Sig_CL03() 
+    >>> p = integer(21281327767482252741932894893985715222965623124768085901716557791820905647984944443933101657552322341359898014680608292582311911954091137905079983298534519)
+    >>> q = integer(25806791860198780216123533220157510131833627659100364815258741328806284055493647951841418122944864389129382151632630375439181728665686745203837140362092027)
+    >>> (public_key, secret_key) = pksig.keygen(1024, p, q)
+    >>> signature = pksig.signCommit(public_key, secret_key, Cx)
+    >>> pksig.verifyCommit(public_key, signature, Cx)
     True
     """
     def __init__(self, lmin=160, lin=160, secparam=512):
@@ -90,13 +118,25 @@ class Sig_CL03(PKSig):
 
         lhs = (sig['v'] ** sig['e']) % pk['N']
         rhs = ((pk['a'] ** m)*(pk['b'] ** sig['s'])*pk['c']) % pk['N']
-
-        #do size check on e
+        
+        if (sig['e'] <= 2**(le - 1) or sig['e'] >= 2**(le)):
+            return False
 
         if(lhs == rhs):
             return True
 
         return False
 
+    def verifyCommit(self, pk, sig, Cx):
+        if debug: print("\nVERIFY\n\n")
 
+        lhs = (sig['v'] ** sig['e']) % pk['N']
+        rhs = (Cx*(pk['b'] ** sig['rprime'])*pk['c']) % pk['N']
 
+        if (sig['e'] <= 2**(le - 1)):
+            return False
+
+        if(lhs == rhs):
+            return True
+
+        return False

--- a/charm/schemes/pksig/pksig_cl03.py
+++ b/charm/schemes/pksig/pksig_cl03.py
@@ -35,11 +35,12 @@ class Sig_CL03(PKSig):
     >>> signature = pksig.sign(public_key, secret_key, msg)
     >>> pksig.verify(public_key, msg, signature)
     True
+    >>> from charm.toolbox.conversion import Conversion
     >>> g  = {}
     >>> m = {}
     >>> j = 16
     >>> for i in range(1, j + 1): g[str(i)] = randomQR(public_key['N'])
-    >>> for i in range(1, j + 1): m[str(i)] = random(public_key['N'])
+    >>> for i in range(1, j + 1): m[str(i)] = integer(SHA1(Conversion.IP2OS(random(public_key['N']))))
     >>> Cx = 1 % public_key['N']
     >>> for i in range(1, len(m) + 1): Cx = Cx*(g[str(i)] ** m[str(i)])
     >>> pksig = Sig_CL03() 


### PR DESCRIPTION
Hi,

I've added a header in implementation of the Camenisch-Lysyanskaya signature together with:
1. verifyCommit function
2. The size of e is now verified in verify and verifyCommit functions
3. A second test has been added in doctest for a block of messages Cx based
   on [CL03], page 8, Section 4, Signing algorithm. I'm not sure if it would be better to use an
   implementation of the Fujisaki-Okamoto commitment, as utilized in [CL03], p.10 for Cx. However, in that case,
   b^s would be redundant in the signCommit function. 

Best regards,
Antonio

PS: I really don't know who was the original author of this implementation.
