### PR TITLE
ECGroup Python 2.7 bytes fix

### DIFF
--- a/charm/toolbox/ecgroup.py
+++ b/charm/toolbox/ecgroup.py
@@ -1,6 +1,7 @@
 try:
    from charm.core.math.elliptic_curve import elliptic_curve,ec_element,ZR,G,init,random,order,getGenerator,bitsize,serialize,deserialize,hashEC,encode,decode,getXY
    import charm.core.math.elliptic_curve as ecc
+   from charm.toolbox import bitstring
 except Exception as err:
    print(err)
    exit(-1)
@@ -66,7 +67,7 @@ class ECGroup():
                 if type(i) == ec_element:
                     s += serialize(i)
                 elif type(i) == str:
-                    s += bytes(str(i), 'utf8')
+                    s += bitstring.getBytes(str(i), 'utf8')
                 elif type(i) == bytes:
                     s += i
                 else:


### PR DESCRIPTION
Changed bytes function to bitstring.getBytes. 'bytes' with second argument crashes at Python 2.7.
