### PR TITLE
setup.py now reads custom libs dirs from config.mk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ else:
 
 _charm_version = opt.get('VERSION')
 lib_config_file = 'charm/config.py'
-
+library_dirs = [s[2:] for s in opt.get('LDFLAGS').split() if s.startswith('-L')]
 if opt.get('PAIR_MOD') == 'yes':
     if opt.get('USE_PBC') == 'yes':
         replaceString(lib_config_file, "pairing_lib=libs ", "pairing_lib=libs.pbc")
@@ -156,7 +156,8 @@ if opt.get('PAIR_MOD') == 'yes':
                                             benchmark_path], 
                             sources = [math_path+'pairing/pairingmodule.c', 
                                         utils_path+'base64.c'],
-                            libraries=['pbc', 'gmp', 'crypto'], define_macros=_macros, undef_macros=_undef_macro)
+                            libraries=['pbc', 'gmp', 'crypto'], define_macros=_macros, undef_macros=_undef_macro,
+                            library_dirs=library_dirs)
 
     elif opt.get('USE_RELIC') == 'yes':
         # check if RELIC lib has been built. if not, bail
@@ -170,7 +171,8 @@ if opt.get('PAIR_MOD') == 'yes':
                             sources = [math_path + 'pairing/relic/pairingmodule3.c',
                                         math_path + 'pairing/relic/relic_interface.c',
                                         utils_path + 'base64.c'],
-                            libraries=['relic', 'gmp', 'crypto'], define_macros=_macros, undef_macros=_undef_macro)
+                            libraries=['relic', 'gmp', 'crypto'], define_macros=_macros, undef_macros=_undef_macro,
+                            library_dirs=library_dirs)
                             #extra_objects=[relic_lib], extra_compile_args=None)
 
     elif opt.get('USE_MIRACL') == 'yes':
@@ -185,7 +187,8 @@ if opt.get('PAIR_MOD') == 'yes':
                             sources = [math_path + 'pairing/miracl/pairingmodule2.c',
                                         math_path + 'pairing/miracl/miracl_interface2.cc'],
                             libraries=['gmp', 'crypto', 'stdc++'], define_macros=_macros, undef_macros=_undef_macro,
-                            extra_objects=[miracl_lib], extra_compile_args=None)
+                            extra_objects=[miracl_lib], extra_compile_args=None,
+                            library_dirs=library_dirs)
 
     _ext_modules.append(pairing_module)
    


### PR DESCRIPTION
Fix a linking error when compiling charm with math libraries installed in custom directories.

Setup.py now reads LDFLAGS from the config.mk file and sets the library_dirs variable of the Extension objects.
