### PR TITLE
Uncompressed (de)serialization of PairingGroup Elements

### DIFF
--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -1533,16 +1533,16 @@ UNARY(instance_invert, 'i', Element_invert)
 BINARY(instance_add, 'a', Element_add)
 BINARY(instance_sub, 's', Element_sub)
 
-static PyObject *Serialize_cmp(Element *o1, PyObject *args) {
+static PyObject *Serialize_cmp(PyObject *self, PyObject *args) {
 
-	Element *self = NULL;
+	Element *element = NULL;
 	int compression = 1;
 
-	if(!PyArg_ParseTuple(args, "O|p:serialize", &self, &compression)) return NULL;
+	if(!PyArg_ParseTuple(args, "O|p:serialize", &element, &compression)) return NULL;
 
-	if(!PyElement_Check(self)) EXIT_IF(TRUE, "not a valid element object.");
-	if(self->elem_initialized == FALSE) {
-		PyErr_SetString(ElementError, "element not initialized.");
+	if(!PyElement_Check(element)) return NULL;
+	if(element->elem_initialized == FALSE) {
+		PyErr_SetString(PyExc_ValueError, "Element not initialized.");
 		return NULL;
 	}
 
@@ -1550,49 +1550,50 @@ static PyObject *Serialize_cmp(Element *o1, PyObject *args) {
 	uint8_t *data_buf = NULL;
 	size_t bytes_written;
 
-	if(self->element_type == ZR || self->element_type == GT) {
-		elem_len = element_length_in_bytes(self->e);
+	if(element->element_type == ZR || element->element_type == GT) {
+		elem_len = element_length_in_bytes(element->e);
 
 		data_buf = (uint8_t *) malloc(elem_len + 1);
 		EXIT_IF(data_buf == NULL, "out of memory.");
 		// write to char buffer
-		bytes_written = element_to_bytes(data_buf, self->e);
+		bytes_written = element_to_bytes(data_buf, element->e);
 		debug("result => ");
 		printf_buffer_as_hex(data_buf, bytes_written);
 	}
-	else if(self->element_type != NONE_G) {
+	else if(element->element_type != NONE_G) {
 	// object initialized now retrieve element and serialize to a char buffer.
 		if(compression){
-			elem_len = element_length_in_bytes_compressed(self->e);
+			elem_len = element_length_in_bytes_compressed(element->e);
 		}else{
-			elem_len = element_length_in_bytes(self->e);
+			elem_len = element_length_in_bytes(element->e);
 		}
 		data_buf = (uint8_t *) malloc(elem_len + 1);
 		EXIT_IF(data_buf == NULL, "out of memory.");
 		// write to char buffer
 		if(compression){
-			bytes_written = element_to_bytes_compressed(data_buf, self->e);
+			bytes_written = element_to_bytes_compressed(data_buf, element->e);
 		} else {
-			bytes_written = element_to_bytes(data_buf, self->e);
+			bytes_written = element_to_bytes(data_buf, element->e);
 		}
 	}
 	else {
-		EXIT_IF(TRUE, "invalid type.\n");
+		PyErr_SetString(PyExc_TypeError, "Invalid element type.");
+		return NULL;
 	}
 
 	// convert to base64 and return as a string?
 	size_t length = 0;
 	char *base64_data_buf = NewBase64Encode(data_buf, bytes_written, FALSE, &length);
-	//PyObject *result = PyUnicode_FromFormat("%d:%s", self->element_type, (const char *) base64_data_buf);
+	//PyObject *result = PyUnicode_FromFormat("%d:%s", element->element_type, (const char *) base64_data_buf);
 	// free(base64_data_buf);
-	PyObject *result = PyBytes_FromFormat("%d:%s", self->element_type, (const char *) base64_data_buf);
+	PyObject *result = PyBytes_FromFormat("%d:%s", element->element_type, (const char *) base64_data_buf);
 	debug("base64 enc => '%s'\n", base64_data_buf);
 	free(base64_data_buf);
 	free(data_buf);
 	return result;
 }
 
-static PyObject *Deserialize_cmp(Element *self, PyObject *args) {
+static PyObject *Deserialize_cmp(PyObject *self, PyObject *args) {
 	Element *origObject = NULL;
 	Pairing *group = NULL;
 	PyObject *object;
@@ -1600,7 +1601,7 @@ static PyObject *Deserialize_cmp(Element *self, PyObject *args) {
 
 	if(!PyArg_ParseTuple(args, "OO|p:deserialize", &group, &object, &compression)) return NULL;
 	VERIFY_GROUP(group);
-	if(!PyBytes_Check(object)) EXIT_IF(TRUE, "nothing to deserialize in element.");
+	if(!PyBytes_Check(object)) return NULL;
 
 	uint8_t *serial_buf = (uint8_t *) PyBytes_AsString(object);
 	int type = atoi((const char *) &(serial_buf[0]));

--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -1534,17 +1534,18 @@ BINARY(instance_add, 'a', Element_add)
 BINARY(instance_sub, 's', Element_sub)
 
 static PyObject *Serialize_cmp(Element *o1, PyObject *args) {
+
 	Element *self = NULL;
 	int compression = 1;
 
-    if(!PyArg_ParseTuple(args, "O|p:serialize", &self, &compression)) return NULL;
+	if(!PyArg_ParseTuple(args, "O|p:serialize", &self, &compression)) return NULL;
 
-    if(!PyElement_Check(self)) EXIT_IF(TRUE, "not a valid element object.");
-    if(self->elem_initialized == FALSE) {
-	    PyErr_SetString(ElementError, "element not initialized.");
-	    return NULL;
-    }
-	
+	if(!PyElement_Check(self)) EXIT_IF(TRUE, "not a valid element object.");
+	if(self->elem_initialized == FALSE) {
+		PyErr_SetString(ElementError, "element not initialized.");
+		return NULL;
+	}
+
 	int elem_len = 0;
 	uint8_t *data_buf = NULL;
 	size_t bytes_written;
@@ -1562,18 +1563,18 @@ static PyObject *Serialize_cmp(Element *o1, PyObject *args) {
 	else if(self->element_type != NONE_G) {
 	// object initialized now retrieve element and serialize to a char buffer.
 		if(compression){
-    		elem_len = element_length_in_bytes_compressed(self->e);
+			elem_len = element_length_in_bytes_compressed(self->e);
 		}else{
-		    elem_len = element_length_in_bytes(self->e);
+			elem_len = element_length_in_bytes(self->e);
 		}
 		data_buf = (uint8_t *) malloc(elem_len + 1);
 		EXIT_IF(data_buf == NULL, "out of memory.");
 		// write to char buffer
 		if(compression){
-    		bytes_written = element_to_bytes_compressed(data_buf, self->e);
-    	} else {
-    	    bytes_written = element_to_bytes(data_buf, self->e);
-    	}
+			bytes_written = element_to_bytes_compressed(data_buf, self->e);
+		} else {
+			bytes_written = element_to_bytes(data_buf, self->e);
+		}
 	}
 	else {
 		EXIT_IF(TRUE, "invalid type.\n");
@@ -1597,40 +1598,37 @@ static PyObject *Deserialize_cmp(Element *self, PyObject *args) {
 	PyObject *object;
 	int compression = 1;
 
-    if(!PyArg_ParseTuple(args, "OO|p:deserialize",
-                         &group, &object, &compression)) return NULL;
-
+	if(!PyArg_ParseTuple(args, "OO|p:deserialize", &group, &object, &compression)) return NULL;
 	VERIFY_GROUP(group);
-	if(PyBytes_Check(object)) {
-		uint8_t *serial_buf = (uint8_t *) PyBytes_AsString(object);
-		int type = atoi((const char *) &(serial_buf[0]));
-		uint8_t *base64_buf = (uint8_t *)(serial_buf + 2);
+	if(!PyBytes_Check(object)) EXIT_IF(TRUE, "nothing to deserialize in element.");
 
-		size_t deserialized_len = 0;
-		uint8_t *binary_buf = NewBase64Decode((const char *) base64_buf, strlen((char *) base64_buf), &deserialized_len);
+	uint8_t *serial_buf = (uint8_t *) PyBytes_AsString(object);
+	int type = atoi((const char *) &(serial_buf[0]));
+	uint8_t *base64_buf = (uint8_t *)(serial_buf + 2);
 
-		if((type == ZR || type == GT) && deserialized_len > 0) {
-//				debug("result => ");
-//				printf_buffer_as_hex(binary_buf, deserialized_len);
-			origObject = createNewElement(type, group);
+	size_t deserialized_len = 0;
+	uint8_t *binary_buf = NewBase64Decode((const char *) base64_buf, strlen((char *) base64_buf), &deserialized_len);
+
+	if((type == ZR || type == GT) && deserialized_len > 0) {
+	//				debug("result => ");
+	//				printf_buffer_as_hex(binary_buf, deserialized_len);
+		origObject = createNewElement(type, group);
+		element_from_bytes(origObject->e, binary_buf);
+		free(binary_buf);
+		return (PyObject *) origObject;
+	}
+	else if((type == G1 || type == G2) && deserialized_len > 0) {
+		// now convert element back to an element type (assume of type ZR for now)
+		origObject = createNewElement(type, group);
+		if(compression) {
+			element_from_bytes_compressed(origObject->e, binary_buf);
+		} else {
 			element_from_bytes(origObject->e, binary_buf);
-			free(binary_buf);
-			return (PyObject *) origObject;
 		}
-		else if((type == G1 || type == G2) && deserialized_len > 0) {
-			// now convert element back to an element type (assume of type ZR for now)
-			origObject = createNewElement(type, group);
-			if(compression) {
-				element_from_bytes_compressed(origObject->e, binary_buf);
-			} else {
-				element_from_bytes(origObject->e, binary_buf);
-			}
-			free(binary_buf);
-			return (PyObject *) origObject;
-		}
+		free(binary_buf);
+		return (PyObject *) origObject;
 	}
 
-	EXIT_IF(TRUE, "nothing to deserialize in element.");
 }
 
 void print_mpz(mpz_t x, int base) {

--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -1541,7 +1541,7 @@ static PyObject *Serialize_cmp(PyObject *self, PyObject *args) {
 	if(!PyArg_ParseTuple(args, "O|p:serialize", &element, &compression)) return NULL;
 
 	if(!PyElement_Check(element)) {
-		PyErr_SetString(PyExc_TypeError, "Invalid element type.");	
+		PyErr_SetString(PyExc_TypeError, "Invalid element type.");
 		return NULL;
 	}
 	if(element->elem_initialized == FALSE) {
@@ -1639,7 +1639,7 @@ static PyObject *Deserialize_cmp(PyObject *self, PyObject *args) {
 		free(binary_buf);
 		return (PyObject *) origObject;
 	}
-	
+
 	PyErr_SetString(PyExc_ValueError, "Nothing to deserialize in element.");
 	return NULL;
 }

--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -1540,7 +1540,10 @@ static PyObject *Serialize_cmp(PyObject *self, PyObject *args) {
 
 	if(!PyArg_ParseTuple(args, "O|p:serialize", &element, &compression)) return NULL;
 
-	if(!PyElement_Check(element)) return NULL;
+	if(!PyElement_Check(element)) {
+		PyErr_SetString(PyExc_TypeError, "Invalid element type.");	
+        return NULL;
+	}
 	if(element->elem_initialized == FALSE) {
 		PyErr_SetString(PyExc_ValueError, "Element not initialized.");
 		return NULL;

--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -1534,19 +1534,17 @@ BINARY(instance_add, 'a', Element_add)
 BINARY(instance_sub, 's', Element_sub)
 
 static PyObject *Serialize_cmp(Element *o1, PyObject *args) {
-
 	Element *self = NULL;
-	if(!PyArg_ParseTuple(args, "O", &self)) {
-		PyErr_SetString(ElementError, "invalid argument.");
-		return NULL;
-	}
+	int compression = 1;
 
-	if(!PyElement_Check(self)) EXIT_IF(TRUE, "not a valid element object.");
-	if(self->elem_initialized == FALSE) {
-		PyErr_SetString(ElementError, "element not initialized.");
-		return NULL;
-	}
+    if(!PyArg_ParseTuple(args, "O|p:serialize", &self, &compression)) return NULL;
 
+    if(!PyElement_Check(self)) EXIT_IF(TRUE, "not a valid element object.");
+    if(self->elem_initialized == FALSE) {
+	    PyErr_SetString(ElementError, "element not initialized.");
+	    return NULL;
+    }
+	
 	int elem_len = 0;
 	uint8_t *data_buf = NULL;
 	size_t bytes_written;
@@ -1563,11 +1561,19 @@ static PyObject *Serialize_cmp(Element *o1, PyObject *args) {
 	}
 	else if(self->element_type != NONE_G) {
 	// object initialized now retrieve element and serialize to a char buffer.
-		elem_len = element_length_in_bytes_compressed(self->e);
+		if(compression){
+    		elem_len = element_length_in_bytes_compressed(self->e);
+		}else{
+		    elem_len = element_length_in_bytes(self->e);
+		}
 		data_buf = (uint8_t *) malloc(elem_len + 1);
 		EXIT_IF(data_buf == NULL, "out of memory.");
 		// write to char buffer
-		bytes_written = element_to_bytes_compressed(data_buf, self->e);
+		if(compression){
+    		bytes_written = element_to_bytes_compressed(data_buf, self->e);
+    	} else {
+    	    bytes_written = element_to_bytes(data_buf, self->e);
+    	}
 	}
 	else {
 		EXIT_IF(TRUE, "invalid type.\n");
@@ -1589,34 +1595,39 @@ static PyObject *Deserialize_cmp(Element *self, PyObject *args) {
 	Element *origObject = NULL;
 	Pairing *group = NULL;
 	PyObject *object;
+	int compression = 1;
 
-	if(PyArg_ParseTuple(args, "OO", &group, &object)) {
-		VERIFY_GROUP(group);
-		if(PyBytes_Check(object)) {
-			uint8_t *serial_buf = (uint8_t *) PyBytes_AsString(object);
-			int type = atoi((const char *) &(serial_buf[0]));
-			uint8_t *base64_buf = (uint8_t *)(serial_buf + 2);
+    if(!PyArg_ParseTuple(args, "OO|p:deserialize",
+                         &group, &object, &compression)) return NULL;
 
-			size_t deserialized_len = 0;
-			uint8_t *binary_buf = NewBase64Decode((const char *) base64_buf, strlen((char *) base64_buf), &deserialized_len);
+	VERIFY_GROUP(group);
+	if(PyBytes_Check(object)) {
+		uint8_t *serial_buf = (uint8_t *) PyBytes_AsString(object);
+		int type = atoi((const char *) &(serial_buf[0]));
+		uint8_t *base64_buf = (uint8_t *)(serial_buf + 2);
 
-			if((type == ZR || type == GT) && deserialized_len > 0) {
+		size_t deserialized_len = 0;
+		uint8_t *binary_buf = NewBase64Decode((const char *) base64_buf, strlen((char *) base64_buf), &deserialized_len);
+
+		if((type == ZR || type == GT) && deserialized_len > 0) {
 //				debug("result => ");
 //				printf_buffer_as_hex(binary_buf, deserialized_len);
-				origObject = createNewElement(type, group);
-				element_from_bytes(origObject->e, binary_buf);
-				free(binary_buf);
-				return (PyObject *) origObject;
-			}
-			else if((type == G1 || type == G2) && deserialized_len > 0) {
-				// now convert element back to an element type (assume of type ZR for now)
-				origObject = createNewElement(type, group);
-				element_from_bytes_compressed(origObject->e, binary_buf);
-				free(binary_buf);
-				return (PyObject *) origObject;
-			}
+			origObject = createNewElement(type, group);
+			element_from_bytes(origObject->e, binary_buf);
+			free(binary_buf);
+			return (PyObject *) origObject;
 		}
-		EXIT_IF(TRUE, "string object malformed.");
+		else if((type == G1 || type == G2) && deserialized_len > 0) {
+			// now convert element back to an element type (assume of type ZR for now)
+			origObject = createNewElement(type, group);
+			if(compression) {
+				element_from_bytes_compressed(origObject->e, binary_buf);
+			} else {
+				element_from_bytes(origObject->e, binary_buf);
+			}
+			free(binary_buf);
+			return (PyObject *) origObject;
+		}
 	}
 
 	EXIT_IF(TRUE, "nothing to deserialize in element.");

--- a/charm/core/math/pairing/pairingmodule.h
+++ b/charm/core/math/pairing/pairingmodule.h
@@ -164,7 +164,7 @@ PyObject *Element_call(Element *elem, PyObject *args, PyObject *kwds);
 void	Element_dealloc(Element* self);
 Element *convertToZR(PyObject *LongObj, PyObject *elemObj);
 
-PyObject *Apply_pairing(Element *self, PyObject *args);
+PyObject *Apply_pairing(PyObject *self, PyObject *args);
 PyObject *sha2_hash(Element *self, PyObject *args);
 
 int exp_rule(GroupType lhs, GroupType rhs);
@@ -205,7 +205,7 @@ void print_mpz(mpz_t x, int base);
 
 #define IS_SAME_GROUP(a, b) \
 	if(strncmp((const char *) a->pairing->hash_id, (const char *) b->pairing->hash_id, ID_LEN) != 0) {	\
-		PyErr_SetString(ElementError, "mixing group elements from different curves.");	\
+		PyErr_SetString(PyExc_ValueError, "mixing group elements from different curves.");	\
 		return NULL;	\
 	}
 

--- a/charm/toolbox/pairinggroup.py
+++ b/charm/toolbox/pairinggroup.py
@@ -98,22 +98,33 @@ class PairingGroup():
         return H(self.Pairing, args, type)
     
     def serialize(self, obj, *, compression=True):
-        """serializes a pairing object into bytes.
-           The optional argument compression [bool] sets compressed
-           representation of the curve elements. Default is True.
-           >>> p = PairingGroup('SS512')
-           >>> v1 = p.random(G1)
-           >>> p.serialize(v1, compression=False)
-           Calling the serialize method without optional parameters activate
-           elements compression, taking about half the space but potentially
-           incurring in high computation costs in the deserialization phase.
+        """Serialize a pairing object into bytes.
+
+           :param compression: serialize the compressed representation of the
+                curve element, taking about half the space but potentially
+                incurring in non-negligible computation costs when
+                deserializing. Default is True for compatibility with previous
+                versions of charm.
+            
+            >>> p = PairingGroup('SS512')
+            >>> v1 = p.random(G1)
+            >>> b1 = p.serialize(v1)
+            >>> b1 == p.serialize(v1, compression=True)
+            True
+            >>> v1 == p.deserialize(b1)
+            True
+            >>> b1 = p.serialize(v1, compression=False)
+            >>> v1 == p.deserialize(b1, compression=False)
+            True
         """
         return serialize(obj, compression)
     
     def deserialize(self, obj, *, compression=True):
-        """deserializes into a pairing object. 
-           The optional argument compression should be the same used in the
-           serialization phase. See the serialize method for details.
+        """Deserialize a bytes serialized element into a pairing object. 
+
+           :param compression: must be used for objects serialized with the
+                compression parameter set to True. Default is True for
+                compatibility with previous versions of charm.
         """
         return deserialize(self.Pairing, obj, compression)
     

--- a/charm/toolbox/pairinggroup.py
+++ b/charm/toolbox/pairinggroup.py
@@ -97,13 +97,26 @@ class PairingGroup():
         """hashes objects into ZR, G1 or G2 depending on the pairing curve"""
         return H(self.Pairing, args, type)
     
-    def serialize(self, obj):
-        """serializes a pairing object into bytes"""
-        return serialize(obj)
+    def serialize(self, obj, *, compression=True):
+        """serializes a pairing object into bytes.
+           Optional arguments 
+            - compression [bool]: curve elements compression [default is True]
+            >>> p = PairingGroup('SS512')
+            >>> v1 = p.random(G1)
+            >>> p.serialize(v1, compression=False)
+            Calling the serialize method without optional parameters activate
+            elements compression, taking about half the space but potentially
+            incurring in high computation costs in the deserialization phase.
+        """
+        return serialize(obj, compression)
     
-    def deserialize(self, obj):
-        """deserializes into a pairing object"""
-        return deserialize(self.Pairing, obj)
+    def deserialize(self, obj, *, compression=True):
+        """deserializes into a pairing object. 
+
+           The optional arguments args should be equal to those used in the
+           serialize method. See the serialize method for details.
+        """
+        return deserialize(self.Pairing, obj, compression)
     
     def debug(self, data, prefix=None):
         if not self._verbose:

--- a/charm/toolbox/pairinggroup.py
+++ b/charm/toolbox/pairinggroup.py
@@ -99,22 +99,21 @@ class PairingGroup():
     
     def serialize(self, obj, *, compression=True):
         """serializes a pairing object into bytes.
-           Optional arguments 
-            - compression [bool]: curve elements compression [default is True]
-            >>> p = PairingGroup('SS512')
-            >>> v1 = p.random(G1)
-            >>> p.serialize(v1, compression=False)
-            Calling the serialize method without optional parameters activate
-            elements compression, taking about half the space but potentially
-            incurring in high computation costs in the deserialization phase.
+           The optional argument compression [bool] sets compressed
+           representation of the curve elements. Default is True.
+           >>> p = PairingGroup('SS512')
+           >>> v1 = p.random(G1)
+           >>> p.serialize(v1, compression=False)
+           Calling the serialize method without optional parameters activate
+           elements compression, taking about half the space but potentially
+           incurring in high computation costs in the deserialization phase.
         """
         return serialize(obj, compression)
     
     def deserialize(self, obj, *, compression=True):
         """deserializes into a pairing object. 
-
-           The optional arguments args should be equal to those used in the
-           serialize method. See the serialize method for details.
+           The optional argument compression should be the same used in the
+           serialization phase. See the serialize method for details.
         """
         return deserialize(self.Pairing, obj, compression)
     


### PR DESCRIPTION
Added support for uncompressed serialization of PairingGroup elements for faster deserialization (for scenarios with not-so-strict storage and network constraints).
To maintain compatibility with existing schemes, the default behavior of the (de)serialization routines is to use compression. Compression can be disabled by using a keyword-only boolean `compression` argument when calling PairingGroup.serialize and PairingGroup.deserialize.

Additionally, serialize, deserialize and pairing product routines now raise standard fine-grained python exceptions (TypeError and ValueError) with more informative messages (especially pairing product).
