### PR TITLE
[bug 135] Fix compilation errors with OpenSSL 1.1.0 caused by API change

### DIFF
--- a/charm/core/math/elliptic_curve/ecmodule.c
+++ b/charm/core/math/elliptic_curve/ecmodule.c
@@ -1318,7 +1318,8 @@ static PyObject *ECE_encode(ECElement *self, PyObject *args) {
                 printf_buffer_as_hex((uint8_t *) input, len);
                 encObj = createNewPoint(G, gobj);
                 BN_bin2bn((const uint8_t *) input, len, x);
-                BN_init(y);
+                BN_free(y);
+                y = BN_new();
                 // Uncomment for debugging purposes
                 //char *xstr = BN_bn2dec(x);
                 //debug("gen x => %s\n", xstr);


### PR DESCRIPTION
The PR changes conversions between OpenSSL Big Numbers, PyLongObjects and MPZ integers. Low level bytes operations which highly depend on internal structures form have been changed to API function calls. This change is justified by the following reasons:
- With OpenSSL 1.1.0, API has changed, no longer allowing for low level operations on Big Numbers. This change caused compilation errors. The PR uses API function calls suggested by OpenSSL manual.
- While the solution may cause a small performance overhead, it is safer as it does not depend on memory structures which potentially may change in the future.

Additionaly, removed `BN_init` function has been replaced with `BN_new`, as suggested by the current OpenSSL manual.