### PR TITLE
Add modulo reduction for group.init of ZR

### DIFF
--- a/charm/core/math/elliptic_curve/ecmodule.c
+++ b/charm/core/math/elliptic_curve/ecmodule.c
@@ -415,6 +415,7 @@ PyObject *ECE_init(ECElement *self, PyObject *args) {
       if(long_obj != NULL) {
         if (_PyLong_Check(long_obj)) {
           setBigNum((PyLongObject *) long_obj, &obj->elemZ);
+          BN_mod(obj->elemZ, obj->elemZ, gobj->order, gobj->ctx);
         } else {
           EXIT_IF(TRUE, "expecting a number (int or long)");
         }


### PR DESCRIPTION
Group initialization didn’t cause the element to be reduced with the modulus. This means that `group.init(ZR, x) != 1 * group.init(ZR, x)` for large values of `x`. To avoid this problem, one could alternatively initialize group elements using `x % group.order()`.