### PR TITLE
Protocol class minor problems

### DIFF
--- a/charm/core/engine/protocol.py
+++ b/charm/core/engine/protocol.py
@@ -3,7 +3,6 @@
 
 from charm.core.engine.util import *
 from charm.toolbox.enum import Enum
-MAX_SIZE = 2048
 
 debug = False
 # standardize responses between client and server
@@ -19,6 +18,7 @@ class Protocol:
         self.party = {}
         self._serialize = False
         self.db = {} # initialize the database
+        self.MAX_SIZE = 2048
         
     def setup(self, *args):
         # handles the hookup between parties involved
@@ -138,7 +138,7 @@ class Protocol:
         # is necessary
         if self._socket != None:
             # block until data is available or remote host closes connection
-            result = self._socket.recv(MAX_SIZE)
+            result = self._socket.recv(self.MAX_SIZE)
             if result == '': return None
             else: 
                 if self._serialize:

--- a/charm/core/engine/util.py
+++ b/charm/core/engine/util.py
@@ -95,7 +95,7 @@ def pickleObject(Object):
     return encoded
 
 def unpickleObject(Object):
-    if type(Object) == str:
+    if type(Object) == str or type(Object) == bytes:
        byte_object = Object
     else:
        return None


### PR DESCRIPTION
Hi all,

I'm trying to create a protocol with charm, and ran into some problems.
The recv_msg function in the Protocol class wasn't working, because unpickleObject didn't allow bytes objects. The other problem was that my messages were getting truncated at 2048, because of MAX_SIZE, and there was no way to tweak this variable from the child class since it was not part of the Protocol class.