### PR TITLE
Improve conversion of Python integers to Big Numbers in EC module

### DIFF
--- a/charm/core/math/elliptic_curve/ecmodule.h
+++ b/charm/core/math/elliptic_curve/ecmodule.h
@@ -34,7 +34,6 @@
 #include <structmember.h>
 #include <longintrepr.h>
 #include <math.h>
-#include <gmp.h>
 #include "benchmarkmodule.h"
 #include "base64.h"
 
@@ -165,7 +164,6 @@ typedef struct {
 #define ElementG(a, b) a->type == G && b->type == G
 #define ElementZR(a, b) a->type == ZR && b->type == ZR
 
-void longObjToMPZ (mpz_t m, PyLongObject * p);
 void setBigNum(PyLongObject *obj, BIGNUM **value);
 PyObject *ECElement_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 int ECElement_init(ECElement *self, PyObject *args, PyObject *kwds);


### PR DESCRIPTION
This commit removes the conversion to MPZ integers when converting a Python long object to an OpenSSL bignum. For the intermediate conversion to a decimal string representation, Python internal functions are used here, however this is arguably less prone to breakage due to potential upcoming CPython changes than accessing internal fields as in the current code. This commit fixes an issue where for instance `group.init(-1) == group.init(1)` or `g == -1 * g` for some group element `g`. As for performance, on my local machine using Python 3.7, this reduces the time spent on `group.init(...)` by more than half; on Python 2.7 I see no significant change.