### PR TITLE
Feature/parameterized policy expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ nosetests.xml
 
 # PyCharm
 .idea
+
+.hypothesis

--- a/charm/core/engine/protocol.py
+++ b/charm/core/engine/protocol.py
@@ -20,7 +20,7 @@ class Protocol:
         self._serialize = False
         self.db = {} # initialize the database
         self.max_size = max_size
-        self.prefix_size = ceil(log(max_size, 2))
+        self.prefix_size = ceil(log(max_size, 256))
         
     def setup(self, *args):
         # handles the hookup between parties involved

--- a/charm/core/math/elliptic_curve/ecmodule.c
+++ b/charm/core/math/elliptic_curve/ecmodule.c
@@ -1009,7 +1009,7 @@ static PyObject *ECE_neg(PyObject *o1) {
 			obj2 = createNewPoint(ZR, obj1->group);
 			if(BN_copy(obj2->elemZ, obj1->elemZ) != NULL) {
 				int negate;
-				if(!BN_is_negative(obj2->elemZ)) negate = -1;
+				if(obj2->elemZ->neg == 0) negate = -1;
 				else negate = 0;
 				BN_set_negative(obj2->elemZ, negate);
 

--- a/charm/core/math/integer/integermodule.c
+++ b/charm/core/math/integer/integermodule.c
@@ -123,12 +123,12 @@ int bnToMPZ(BIGNUM *p, mpz_t m) {
 	size_t count = BN_num_bytes(p);
 	unsigned char* tmp = malloc(count);
 	if(!tmp) {
-		return FALSE;
+	    return FALSE;
 	}
 	BN_bn2bin(p, tmp);
 	mpz_import(m, count, 1, 1, 0, 0, tmp);
-	if(BN_is_negative(p)) {
-		mpz_neg(m, m);
+	if(p->neg != 0) {
+	    mpz_neg(m, m);
 	}
 	free(tmp);
 

--- a/charm/test/schemes/abenc/abenc_yllc15_test.py
+++ b/charm/test/schemes/abenc/abenc_yllc15_test.py
@@ -52,6 +52,7 @@ class YLLC15Test(unittest.TestCase):
 
     @pytest.mark.skipif(sys.version_info < (3, 4),
                         reason="requires python3.4 or higher")
+    @settings(deadline=400, max_examples=50)
     @given(policy=policy_expressions())
     def test_policy_not_satisfied(self, policy):
         pkcs, skcs = self.abe.ukgen(self.params, "aws@amazonaws.com")

--- a/charm/test/schemes/abenc/abenc_yllc15_test.py
+++ b/charm/test/schemes/abenc/abenc_yllc15_test.py
@@ -21,9 +21,6 @@ class YLLC15Test(unittest.TestCase):
         self.abe = YLLC15(group)
         (self.params, self.msk) = self.abe.setup()
 
-    def test_ukgen(self, user_id='bob@example.com'):
-        (public_key, secret_key) = self.abe.ukgen(self.params, user_id)
-
     @pytest.mark.skipif(sys.version_info < (3, 4),
                         reason="requires python3.4 or higher")
     @given(attrs=lists(attributes(), min_size=1))

--- a/charm/toolbox/policy_expression_spec.py
+++ b/charm/toolbox/policy_expression_spec.py
@@ -1,14 +1,23 @@
 from hypothesis.strategies import text, composite, sampled_from, characters, one_of, integers
 
 
-def policy_expressions():
-    return one_of(attributes(), inequalities(), policy_expression())
+def policy_expressions(min_leaves=1, max_leaves=25):
+    return integers(min_leaves, max_leaves).flatmap(policy_expressions_of_size)
+
+
+def policy_expressions_of_size(num_leaves):
+    if num_leaves == 1:
+        return one_of(attributes(), inequalities())
+    else:
+        return policy_expression(num_leaves)
 
 
 @composite
-def policy_expression(draw):
-    left = draw(policy_expressions())
-    right = draw(policy_expressions())
+def policy_expression(draw, num_leaves):
+    left_leaves = draw(integers(min_value=1, max_value=num_leaves - 1))
+    right_leaves = num_leaves - left_leaves
+    left = draw(policy_expressions_of_size(left_leaves))
+    right = draw(policy_expressions_of_size(right_leaves))
     gate = draw(gates())
     return u'(' + u' '.join((left, gate, right)) + u')'
 


### PR DESCRIPTION
Parameterize `policy_expressions` to allow control of `max_leaves` and `min_leaves`.

Useful for performance testing when you want to control the size of the expression.