### PR TITLE
Use math.gcd instead of fractions.gcd

### DIFF
--- a/charm/schemes/abenc/abenc_tbpre_lww14.py
+++ b/charm/schemes/abenc/abenc_tbpre_lww14.py
@@ -21,7 +21,11 @@ from functools import reduce
 # taken from https://gist.github.com/endolith/114336
 def gcd(*numbers):
     """Return the greatest common divisor of the given integers"""
-    from fractions import gcd
+    import sys
+    if sys.version_info < (3, 5):
+        from fractions import gcd
+    else:
+        from math import gcd
     return reduce(gcd, numbers)
 
 # taken from https://gist.github.com/endolith/114336

--- a/charm/schemes/lem_scheme.py
+++ b/charm/schemes/lem_scheme.py
@@ -23,7 +23,10 @@ from charm.core.engine.util import *
 from datetime import datetime
 from time import mktime
 import hashlib , os , math, sys, random
-from fractions import gcd
+if sys.version_info < (3, 5):
+    from fractions import gcd
+else:
+    from math import gcd
 from timeit import default_timer as timer
 
 #This generates values of p,q,n and n2


### PR DESCRIPTION
Hi there,
while running the charm test I got the following warning (see also [Python documentation](https://docs.python.org/3.7/library/fractions.html#fractions.gcd)):

    DeprecationWarning: fractions.gcd() is deprecated. Use math.gcd()
    instead.

This PR makes the according changes to use `math.gcd`.