### PR TITLE
Support all-AND policy expressions for testing ABE schemes.

### DIFF
--- a/charm/test/toolbox/test_policy_expression.py
+++ b/charm/test/toolbox/test_policy_expression.py
@@ -2,11 +2,15 @@ import unittest
 
 from hypothesis import given
 
-from charm.toolbox.policy_expression_spec import policy_expressions, assert_valid
+from charm.toolbox.policy_expression_spec import policy_expressions, assert_valid, alland_policy_expressions
 
 
 class TestPolicyExpressionSpec(unittest.TestCase):
 
     @given(policy_expressions())
     def test_policy_expression_spec(self, policy_expression):
+        assert_valid(policy_expression)
+
+    @given(alland_policy_expressions())
+    def test_allAND_policy_expressions(self, policy_expression):
         assert_valid(policy_expression)

--- a/charm/toolbox/policy_expression_spec.py
+++ b/charm/toolbox/policy_expression_spec.py
@@ -1,25 +1,44 @@
 from hypothesis.strategies import text, composite, sampled_from, characters, one_of, integers
+from functools import partial
 
 
-def policy_expressions(min_leaves=1, max_leaves=25):
-    return integers(min_leaves, max_leaves).flatmap(policy_expressions_of_size)
-
-
-def policy_expressions_of_size(num_leaves):
+def policy_expressions_of_size(policy_expression_strategy, num_leaves):
     if num_leaves == 1:
         return one_of(attributes(), inequalities())
     else:
-        return policy_expression(num_leaves)
+        return policy_expression_strategy(num_leaves)
 
 
 @composite
-def policy_expression(draw, num_leaves):
+def monotonic_policy_expression(draw, num_leaves):
     left_leaves = draw(integers(min_value=1, max_value=num_leaves - 1))
     right_leaves = num_leaves - left_leaves
-    left = draw(policy_expressions_of_size(left_leaves))
-    right = draw(policy_expressions_of_size(right_leaves))
+    left = draw(monotonic_policy_expressions_of_size(left_leaves))
+    right = draw(monotonic_policy_expressions_of_size(right_leaves))
     gate = draw(gates())
     return u'(' + u' '.join((left, gate, right)) + u')'
+
+
+@composite
+def alland_policy_expression(draw, num_leaves):
+    left_leaves = draw(integers(min_value=1, max_value=num_leaves - 1))
+    right_leaves = num_leaves - left_leaves
+    left = draw(alland_policy_expressions_of_size(left_leaves))
+    right = draw(alland_policy_expressions_of_size(right_leaves))
+    gate = draw(and_gates())
+    return u'(' + u' '.join((left, gate, right)) + u')'
+
+
+monotonic_policy_expressions_of_size = partial(policy_expressions_of_size, monotonic_policy_expression)
+alland_policy_expressions_of_size = partial(policy_expressions_of_size, alland_policy_expression)
+
+
+def policy_expressions(min_leaves=1, max_leaves=25):
+    return integers(min_leaves, max_leaves).flatmap(monotonic_policy_expressions_of_size)
+
+
+def alland_policy_expressions(min_leaves=1, max_leaves=25):
+    return integers(min_leaves, max_leaves).flatmap(alland_policy_expressions_of_size)
 
 
 def attributes():
@@ -40,6 +59,10 @@ def inequality_operators():
 
 def gates():
     return sampled_from((u'or', u'and'))
+
+
+def and_gates():
+    return sampled_from((u'and',))
 
 
 def assert_valid(policy_expression):


### PR DESCRIPTION
All-AND access policy expressions represent the worst-case computational overhead.