### PR TITLE
Add instructions for newer Python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER support@charm-crypto.com
 
 RUN apt update && apt install --yes build-essential flex bison wget subversion m4 python3 python3-dev python3-setuptools libgmp-dev libssl-dev

--- a/configure.sh
+++ b/configure.sh
@@ -468,7 +468,7 @@ fi
 
 # Python version handling logic. We prefer the argument path given by --python 
 # If not specified, we check if python is python 3. 
-#Baring that, we try python3,python3.2.python3.1,etc 
+# Baring that, we try python3, python3.8, python3.7, etc 
 
 python3_found="no"
 is_python_version(){
@@ -502,7 +502,7 @@ if [ -n "$python_path" ]; then
             exit 1
         fi 
 else
-        for pyversion in python python3 python3.2 python3.1 
+        for pyversion in python python3 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 
         do 
             if (is_python_version `which $pyversion`); then
                 python3_found="yes"


### PR DESCRIPTION
This PR updates the installation instructions to explain how to use newer Python versions. The implementation already works with these newer versions; only `Dockerfile` and `configure.sh` had to be updated slightly.

I have tested the updated code in a Ubuntu VM and in a Ubuntu container and some sample code works as intended.

I noted that some files still implicitly assume that Python 3.2 is being used, but that would require a larger refactor to get it to work with arbitrary Python versions. These files are not part of Charm itself but rather of the installation process. These files are as follows:
* `installers/osx.installer/build-osx-installer.sh`
* `installers/osx.installer/Charm Crypto.pkgproj`
* `installers/win.installer/charm-exe-script.nsi`
