### PR TITLE
Support multiple ABEnc adapters with varying schemes

### DIFF
--- a/charm/adapters/abenc_adapt_hybrid.py
+++ b/charm/adapters/abenc_adapt_hybrid.py
@@ -22,20 +22,19 @@ class HybridABEnc(ABEnc):
     """
     def __init__(self, scheme, groupObj):
         ABEnc.__init__(self)
-        global abenc
         # check properties (TODO)
-        abenc = scheme
+        self.abenc = scheme
         self.group = groupObj
             
     def setup(self):
-        return abenc.setup()
+        return self.abenc.setup()
     
     def keygen(self, pk, mk, object):
-        return abenc.keygen(pk, mk, object)
+        return self.abenc.keygen(pk, mk, object)
     
     def encrypt(self, pk, M, object):
         key = self.group.random(GT)
-        c1 = abenc.encrypt(pk, key, object)
+        c1 = self.abenc.encrypt(pk, key, object)
         # instantiate a symmetric enc scheme from this key
         cipher = AuthenticatedCryptoAbstraction(sha2(key))
         c2 = cipher.encrypt(M)
@@ -43,7 +42,7 @@ class HybridABEnc(ABEnc):
     
     def decrypt(self, pk, sk, ct):
         c1, c2 = ct['c1'], ct['c2']
-        key = abenc.decrypt(pk, sk, c1)
+        key = self.abenc.decrypt(pk, sk, c1)
         if key is False:
             raise Exception("failed to decrypt!")
         cipher = AuthenticatedCryptoAbstraction(sha2(key))


### PR DESCRIPTION
When instantiating multiple HybridABEnc adapters with varying ABEnc schemes, the last ABEnc scheme overwrites the keygen/encrypt/decrypt functions for all other adapters.

Small test case:
```python
>>> from charm.toolbox.pairinggroup import PairingGroup
>>> from charm.schemes.abenc.abenc_bsw07 import CPabe_BSW07
>>> from charm.schemes.abenc.abenc_waters09 import CPabe09
>>> from charm.adapters.abenc_adapt_hybrid import HybridABEnc
>>> group = PairingGroup("SS512")
>>> bsw07 = CPabe_BSW07(group)
>>> mpk, mk = bsw07.setup()
>>> waters09 = CPabe09(group)
>>> hyb_bsw07 = HybridABEnc(bsw07, group)
>>> hyb_bsw07.encrypt(mpk, b"foo", "A AND B")
{'c1': ... } # Correct result
>>> hyb_waters09 = HybridABEnc(waters09, group)
>>> hyb_bsw07.encrypt(mpk, b"foo", "A AND B")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/Charm_Crypto-0.50-py3.6-linux-x86_64.egg/charm/adapters/abenc_adapt_hybrid.py", line 38, in encrypt
    c1 = abenc.encrypt(pk, key, object)
  File "/usr/local/lib/python3.6/dist-packages/Charm_Crypto-0.50-py3.6-linux-x86_64.egg/charm/schemes/abenc/abenc_waters09.py", line 69, in encrypt
    C_tilde = (pk['e(gg)^alpha'] ** s) * M
KeyError: 'e(gg)^alpha'
```