### PR TITLE
Changes to fix Relic integration

### DIFF
--- a/charm/core/math/pairing/relic/pairingmodule3.c
+++ b/charm/core/math/pairing/relic/pairingmodule3.c
@@ -112,7 +112,7 @@ PyObject *intToLongObj(integer_t x)
 {
 	/* borrowed from gmpy */
 	int size, isNeg = (bn_sign(x) == BN_NEG) ? TRUE : FALSE;
-	bn_size_str(&size, x, 2);
+	size = bn_size_str(x, 2);
 	size = (size + PyLong_SHIFT - 1) / PyLong_SHIFT;
 	int i;
 	integer_t m;

--- a/charm/core/math/pairing/relic/relic_interface.c
+++ b/charm/core/math/pairing/relic/relic_interface.c
@@ -310,20 +310,20 @@ status_t element_to_str(char *data, int len, element_t e)
     		bn_write_str(data, str_len, e->bn, DBASE);
     	}
     	else if(e->type == G1) {
-			g1_write_str(e->g1, tmp1, str_len);
+			charm_g1_write_str(e->g1, tmp1, str_len);
 
 			int dist_y = FP_STR;
 			snprintf(data, len, "[%s, %s]", tmp1, &(tmp1[dist_y]));
     	}
     	else if(e->type == G2) {
-			g2_write_str(e->g2, tmp1, str_len);
+			charm_g2_write_str(e->g2, tmp1, str_len);
 
 			int len2 = FP_STR;
 			int dist_x1 = len2, dist_y0 = len2 * 2, dist_y1 = len2 * 3;
 			snprintf(data, len, "[%s, %s, %s, %s]", tmp1, &(tmp1[dist_x1]), &(tmp1[dist_y0]), &(tmp1[dist_y1]));
     	}
     	else if(e->type == GT) {
-			gt_write_str(e->gt, tmp1, str_len);
+			charm_gt_write_str(e->gt, tmp1, str_len);
 
     		int len2 = FP_STR;
     		int dist_x01 = len2, dist_x10 = len2 * 2, dist_x11 = len2 * 3,
@@ -879,7 +879,7 @@ int element_length(element_t e)
 	return 0;
 }
 
-status_t g1_read_bin(g1_t g, uint8_t *data, int data_len)
+status_t charm_g1_read_bin(g1_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	fp_read_bin(g->x, data, FP_BYTES);
@@ -890,7 +890,7 @@ status_t g1_read_bin(g1_t g, uint8_t *data, int data_len)
 	return ELEMENT_OK;
 }
 
-status_t g1_write_bin(g1_t g, uint8_t *data, int data_len)
+status_t charm_g1_write_bin(g1_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	if(data_len < G1_LEN) return ELEMENT_INVALID_ARG_LEN;
@@ -914,7 +914,7 @@ status_t g1_write_bin(g1_t g, uint8_t *data, int data_len)
 	return ELEMENT_OK;
 }
 
-status_t g1_write_str(g1_t g, uint8_t *data, int data_len)
+status_t charm_g1_write_str(g1_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	if(data_len < G1_LEN*2) return ELEMENT_INVALID_ARG_LEN;
@@ -929,7 +929,7 @@ status_t g1_write_str(g1_t g, uint8_t *data, int data_len)
 }
 
 
-status_t g2_read_bin(g2_t g, uint8_t *data, int data_len)
+status_t charm_g2_read_bin(g2_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	if(data_len < G2_LEN) return ELEMENT_INVALID_ARG_LEN;
@@ -950,7 +950,7 @@ status_t g2_read_bin(g2_t g, uint8_t *data, int data_len)
 	return ELEMENT_OK;
 }
 
-status_t g2_write_bin(g2_t g, uint8_t *data, int data_len)
+status_t charm_g2_write_bin(g2_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 //	int out_len = (FP_BYTES * 4) + 4;
@@ -982,7 +982,7 @@ status_t g2_write_bin(g2_t g, uint8_t *data, int data_len)
 	return ELEMENT_OK;
 }
 
-status_t g2_write_str(g2_t g, uint8_t *data, int data_len)
+status_t charm_g2_write_str(g2_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	int G2_STR = G2_LEN*4;
@@ -1002,7 +1002,7 @@ status_t g2_write_str(g2_t g, uint8_t *data, int data_len)
 }
 
 
-status_t gt_read_bin(gt_t g, uint8_t *data, int data_len)
+status_t charm_gt_read_bin(gt_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	if(data_len < GT_LEN) return ELEMENT_INVALID_ARG_LEN;
@@ -1040,7 +1040,7 @@ status_t gt_read_bin(gt_t g, uint8_t *data, int data_len)
 	return ELEMENT_OK;
 }
 
-status_t gt_write_bin(gt_t g, uint8_t *data, int data_len)
+status_t charm_gt_write_bin(gt_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	if(data_len < GT_LEN) return ELEMENT_INVALID_ARG_LEN;
@@ -1090,7 +1090,7 @@ status_t gt_write_bin(gt_t g, uint8_t *data, int data_len)
 	return ELEMENT_OK;
 }
 
-status_t gt_write_str(gt_t g, uint8_t *data, int data_len)
+status_t charm_gt_write_str(gt_t g, uint8_t *data, int data_len)
 {
 	if(g == NULL) return ELEMENT_UNINITIALIZED;
 	if(data_len < GT_LEN*3) return ELEMENT_INVALID_ARG_LEN;
@@ -1134,13 +1134,13 @@ status_t element_from_bytes(element_t e, unsigned char *data, int data_len)
 		bn_read_bin(e->bn, data, data_len);
 	}
 	else if(type == G1) {
-		return g1_read_bin(e->g1, data, data_len); // x & y
+		return charm_g1_read_bin(e->g1, data, data_len); // x & y
 	}
 	else if(type == G2) {
-		return g2_read_bin(e->g2, data, data_len); // x1, y1  & x2, y2
+		return charm_g2_read_bin(e->g2, data, data_len); // x1, y1  & x2, y2
 	}
 	else if(type == GT) {
-		return gt_read_bin(e->gt, data, data_len); // x1-6 && y1-6
+		return charm_gt_read_bin(e->gt, data, data_len); // x1-6 && y1-6
 	}
 	else {
 		return ELEMENT_INVALID_TYPES;
@@ -1157,13 +1157,13 @@ status_t element_to_bytes(unsigned char *data, int data_len, element_t e)
 		bn_write_bin(data, data_len, e->bn);
 	}
 	else if(type == G1) {
-		return g1_write_bin(e->g1, data, data_len); // x & y
+		return charm_g1_write_bin(e->g1, data, data_len); // x & y
 	}
 	else if(type == G2) {
-		return g2_write_bin(e->g2, data, data_len); // x1, y1  & x2, y2
+		return charm_g2_write_bin(e->g2, data, data_len); // x1, y1  & x2, y2
 	}
 	else if(type == GT) {
-		return gt_write_bin(e->gt, data, data_len); // x1-6 && y1-6
+		return charm_gt_write_bin(e->gt, data, data_len); // x1-6 && y1-6
 	}
 	else {
 		return ELEMENT_INVALID_TYPES;

--- a/charm/core/math/pairing/relic/relic_interface.h
+++ b/charm/core/math/pairing/relic/relic_interface.h
@@ -56,6 +56,19 @@ typedef enum _status_t { ELEMENT_OK = 2,
 enum Group {ZR, G1, G2, GT, NONE_G};
 typedef enum Group GroupType;
 
+//new macros to fix Relic renaming
+#define FP_BYTES RLC_FP_BYTES
+#define fp_write fp_write_str
+#define BN_BYTES (RLC_BN_DIGS * sizeof(dig_t))
+#define BN_NEG RLC_NEG
+#define BN_POS RLC_POS
+#define STS_OK RLC_OK
+#define G1_TABLE RLC_G1_TABLE
+#define G2_TABLE RLC_G2_TABLE
+#define CMP_GT RLC_GT
+#define CMP_EQ RLC_EQ
+//end new macros
+
 #define FP_STR FP_BYTES * 2 + 1
 #define G1_LEN (FP_BYTES * 2) + 2
 #define G2_LEN (FP_BYTES * 4) + 4
@@ -158,17 +171,17 @@ status_t element_to_bytes(unsigned char *data, int data_len, element_t e);
 status_t element_from_bytes(element_t e, unsigned char *data, int data_len);
 
 void print_as_hex(uint8_t *data, size_t len);
-status_t g1_read_bin(g1_t g, uint8_t *data, int data_len);
-status_t g1_write_bin(g1_t g, uint8_t *data, int data_len);
-status_t g1_write_str(g1_t g, uint8_t *data, int data_len);
+status_t charm_g1_read_bin(g1_t g, uint8_t *data, int data_len);
+status_t charm_g1_write_bin(g1_t g, uint8_t *data, int data_len);
+status_t charm_g1_write_str(g1_t g, uint8_t *data, int data_len);
 
-status_t g2_read_bin(g2_t g, uint8_t *data, int data_len);
-status_t g2_write_bin(g2_t g, uint8_t *data, int data_len);
-status_t g2_write_str(g2_t g, uint8_t *data, int data_len);
+status_t charm_g2_read_bin(g2_t g, uint8_t *data, int data_len);
+status_t charm_g2_write_bin(g2_t g, uint8_t *data, int data_len);
+status_t charm_g2_write_str(g2_t g, uint8_t *data, int data_len);
 
-status_t gt_read_bin(gt_t g, uint8_t *data, int data_len);
-status_t gt_write_bin(gt_t g, uint8_t *data, int data_len);
-status_t gt_write_str(gt_t g, uint8_t *data, int data_len);
+status_t charm_gt_read_bin(gt_t g, uint8_t *data, int data_len);
+status_t charm_gt_write_bin(gt_t g, uint8_t *data, int data_len);
+status_t charm_gt_write_str(gt_t g, uint8_t *data, int data_len);
 
 #define bn_inits(b) \
 		bn_null(b);	\


### PR DESCRIPTION
#220 

Added the fixes I came up with to compile the Charm module with a Relic backend for pairing. 

For the functions that had name conflicts with existing functions in Relic, I added `charm_` as a prefix. I also added this to the `g#_write_str` functions even though they had no name conflict in order to keep a consistent naming convention for those families of functions.

I tested by generating random G1, G2, GT, ZR points on the BN254 curve in Python and making sure all expected arithmetic worked and the pairing function worked. If there are additional things I should check, please let me know.