### PR TITLE
docs: fix simple typo, attriute -> attribute

### DIFF
--- a/charm/schemes/abenc/pk_hve08.py
+++ b/charm/schemes/abenc/pk_hve08.py
@@ -45,7 +45,7 @@ class HVE08:
         return (pk, msk)
 
     def keygen(self, pk, msk, yVector):
-        """yVector: expects binary attributes of 0 or 1 and "dont care" attriute is represented by the value 2.
+        """yVector: expects binary attributes of 0 or 1 and "dont care" attribute is represented by the value 2.
         """
         g1 = pk['g1']
         g2 = pk['g2']


### PR DESCRIPTION
There is a small typo in charm/schemes/abenc/pk_hve08.py.

Should read `attribute` rather than `attriute`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md