### PR TITLE
Fix Issue #313 and optimize based on Issue #312

### DIFF
--- a/charm/toolbox/pairinggroup.py
+++ b/charm/toolbox/pairinggroup.py
@@ -27,6 +27,7 @@ class PairingGroup():
  
         self.secparam = secparam # number of bits
         self._verbose = verbose
+        self.__gt = pair(self.random(G1), self.random(G2))
     
     def __str__(self):
         return str(self.Pairing)
@@ -61,7 +62,7 @@ class PairingGroup():
         return self.param
         
     def messageSize(self):
-        return self.secparam / 8        
+        return self.secparam >> 3        
 
     def init(self, type, value=None):
         """initializes an object with a specified type and value""" 
@@ -69,23 +70,20 @@ class PairingGroup():
             return init(self.Pairing, type, value)
         return init(self.Pairing, type)
             
-    def random(self, _type=ZR, count=1, seed=None):
-        """selects a random element in ZR, G1, G2 and GT"""
-        if _type == GT: return self.__randomGT()
-        elif _type in [ZR, G1, G2]:
-            if seed != None and count == 1:
-                return random(self.Pairing, _type, seed)
-            elif count > 1:
-                return tuple([random(self.Pairing, _type) for i in range(count)])                
-            return random(self.Pairing, _type)
-        return None
-
-        
-    def __randomGT(self):
-        if not hasattr(self, 'gt'):
-            self.gt = pair(self.random(G1), self.random(G2))
-        z = self.random(ZR)
-        return self.gt ** z
+    def random(self, _type = ZR, count = 1, seed = None):
+        """selects one or more random elements in ZR, G1, G2 and GT"""
+        if _type == GT:
+            if 1 == count:
+                return self.__gt ** (random(self.Pairing, ZR) if seed is None else random(self.Pairing, ZR, seed))
+            elif count >= 2:
+                return tuple(self.__gt ** random(self.Pairing, ZR) for _ in range(count))
+        elif _type in (ZR, G1, G2):
+            if 1 == count:
+                return random(self.Pairing, _type) if seed is None else random(self.Pairing, _type, seed)
+            elif count >= 2:
+                return tuple(random(self.Pairing, _type) for _ in range(count))
+        else:
+            return None
     
     def encode(self, message):
         raise NotImplementedException

--- a/charm/toolbox/pairinggroup.py
+++ b/charm/toolbox/pairinggroup.py
@@ -8,7 +8,7 @@ except Exception as err:
   exit(-1)
 
 class PairingGroup():
-    def __init__(self, param_id, param_file=False, secparam=512, verbose=False):
+    def __init__(self, param_id, param_file = False, secparam = 512, verbose = False, seed1 = None, seed2 = None):
         #legacy handler to handle calls that still pass in a file path
         if param_file:
           self.Pairing = pairing(file=param_id)
@@ -27,7 +27,7 @@ class PairingGroup():
  
         self.secparam = secparam # number of bits
         self._verbose = verbose
-        self.__gt = pair(self.random(G1), self.random(G2))
+        self.__gt = pair(self.random(G1, seed = seed1), self.random(G2, seed = seed2))
     
     def __str__(self):
         return str(self.Pairing)


### PR DESCRIPTION
Issue #313
- Fix the multiple GT element generation issue. 
- Modify the original recursive logic to a simpler ``if-else`` logic. 
- Pre-generate the ``__gt`` when the object is instantiated, without having to check whether ``__gt`` has been generated every time a random GT element is required to be generated. 
- No seeds will be passed to the imported ``random`` function to generate different random elements when multiple elements are required to be generated even though a seed is specified to call the ``random`` method of the ``PairingGroup`` class. 

Issue #312
- Optimize the ``/ 8`` to ``>> 3``. 

---

There should be two commits in this pull request. If the official thinks adding ``seed1`` and ``seed2`` in the construction function of the ``PairingGroup`` class can destroy the consistency with constructors of other classes, please kindly refer to the first commit, or remove the two parameters in the construction function directly. 

---

Tested on Ubuntu 24.04.1 LTS: 

<img width="1271" alt="38483c971df32f2ff04f0364d34f19d" src="https://github.com/user-attachments/assets/e8a3d1d7-7eac-4e64-ba96-e3d7ce168188" />

Thank you so much for offering this opportunity. 
