### PR TITLE
Fix: Added missing downcaseTokens function to policytree.py

### DIFF
--- a/charm/toolbox/policytree.py
+++ b/charm/toolbox/policytree.py
@@ -36,6 +36,9 @@ def createTree(op, node1, node2):
     node.addSubNode(node1, node2)
     return node
 
+def downcaseTokens(s, loc, toks):
+    return [t.lower() for t in toks]
+
 class PolicyParser:
     def __init__(self, verbose=False):
         self.finalPol = self.getBNF()


### PR DESCRIPTION
`downcaseTokens` was missing from `policytree.py`, causing a `NameError`.
This PR adds the function definition to fix the issue.
