### PR TITLE
Fix Lagrange Coefficient Key Mismatch in CPabe_BSW07.decrypt

### DIFF
--- a/charm/toolbox/secretutil.py
+++ b/charm/toolbox/secretutil.py
@@ -33,12 +33,13 @@ class SecretUtil:
         """recovers the coefficients over a binary tree."""
         coeff = {}
         list2 = [self.group.init(ZR, i) for i in list]
-        for i in list2:
+        for idx, i in enumerate(list):
+            i_zr = list2[idx]  # self.group.init(ZR, i)
             result = 1
-            for j in list2:
-                if not (i == j):
+            for j_zr in list2:
+                if not (i_zr == j_zr):
                     # lagrange basis poly
-                    result *= (0 - j) / (i - j)
+                    result *= (0 - j_zr) / (i_zr - j_zr)
 #                print("coeff '%d' => '%s'" % (i, result))
             coeff[int(i)] = result
         return coeff


### PR DESCRIPTION
During use, we discovered that the `decrypt` method in the `CPabe_BSW07` class wasn’t executing correctly, throwing the error:

> local variable 'output' referenced before assignment
> element not initialized

After investigation, we traced the problem to the `_getCoefficientsDict` function in charm/toolbox/secretutil.py, which wasn’t producing the correct Lagrange coefficients. Although `_getCoefficientsDict` calls `recoverCoefficients`, the keys in its `this_coeff` dictionary didn’t match the logic expected by `recoverCoefficients`. We’ve made a small adjustment to `recoverCoefficients` to align the keys and fix the bug.
