### PR TITLE
Fix Issue #326: Adapt to PyLongObject changes in Python 3.12+

### DIFF
--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -29,16 +29,20 @@
 
 #include "pairingmodule.h"
 
+// PEP 757 – C API to import-export Python integers
 #if PY_MINOR_VERSION <= 11
-  #define PythonLongVal(l, i) l->ob_digit[i]
-#else 
-  #define PythonLongVal(l, i)  l->long_value.ob_digit[i]
+  #define PyLongObj_Val(l, i)  (l)->ob_digit[i]
+  #define PyLongObj_Size(l)  Py_SIZE(l)
+#else
+  #define PyLongObj_Val(l, i)  (l)->long_value.ob_digit[i]
+  // #define _PyLong_SIZE_SHIFTS __builtin_popcount(_PyLong_NON_SIZE_BITS)
+  #define _PyLong_SIZE_SHIFTS 2
+  #define PyLongObj_Size(l)  ((l)->long_value.lv_tag >> _PyLong_SIZE_SHIFTS)
 #endif
 
+// PEP 674 – Disallow using macros as l-values
 #if PY_MINOR_VERSION <= 10
-  #define PYTHON_SET_SIZE(l, i) Py_SIZE(l) = i
-#else
-  #define PYTHON_SET_SIZE(l, i) Py_SET_SIZE(l, i);
+  #define Py_SET_SIZE(l, i)  do { Py_SIZE(l) = (i) } while (0)
 #endif
 		  
 int exp_rule(GroupType lhs, GroupType rhs)
@@ -133,18 +137,17 @@ PyObject *mpzToLongObj (mpz_t m)
 	mpz_init_set (temp, m);
 	for (i = 0; i < size; i++)
 	{
-		PythonLongVal(l, i) = (digit) (mpz_get_ui (temp) & PyLong_MASK);
+		PyLongObj_Val(l, i) = (digit) (mpz_get_ui (temp) & PyLong_MASK);
 		mpz_fdiv_q_2exp (temp, temp, PyLong_SHIFT);
 	}
 	i = size;
-	while ((i > 0) && (PythonLongVal(l, i - 1) == 0))
+	while ((i > 0) && (PyLongObj_Val(l, i - 1) == 0))
 		i--;
 	if(isNeg) {
-		// Py_SET_SIZE(l,-i);
-		PYTHON_SET_SIZE(l, -i);
+		Py_SET_SIZE(l, -i);
 	}
 	else {
-		PYTHON_SET_SIZE(l, i);
+		Py_SET_SIZE(l, i);
 	}
 	mpz_clear (temp);
 	return (PyObject *) l;
@@ -152,7 +155,7 @@ PyObject *mpzToLongObj (mpz_t m)
 
 void longObjToMPZ (mpz_t m, PyLongObject * p)
 {
-	int size, i, tmp = Py_SIZE(p);
+	int size, i, tmp = PyLongObj_Size(p);
 	int isNeg = FALSE;
 	mpz_t temp, temp2;
 	mpz_init (temp);
@@ -166,7 +169,7 @@ void longObjToMPZ (mpz_t m, PyLongObject * p)
 	mpz_set_ui (m, 0);
 	for (i = 0; i < size; i++)
 	{
-		mpz_set_ui (temp, PythonLongVal(p, i));
+		mpz_set_ui (temp, PyLongObj_Val(p, i));
 		mpz_mul_2exp (temp2, temp, PyLong_SHIFT * i);
 		mpz_add (m, m, temp2);
 	}


### PR DESCRIPTION
In Python 3.12 and newer, the `PyLongObject` struct was changed, making `Py_SIZE()` unreliable for getting the length of the digit array. This issue caused `longObjToMPZ()` to incorrectly determine the length of `long_obj` during the initialization of `Element_elem()`, leading to incorrect conversion behavior.

The following changes have been implemented:

1. Introduced `PyLongObj_Size` macro to calculate the size of `PyLongObject` struct.
2. Renamed `PythonLongVal` to `PyLongObj_Val` to improve naming consistency.

**Note:** Further adjustments may be required for Python 3.14+ due to potential shifts to new C APIs, as detailed in [PEP 757](https://peps.python.org/pep-0757/).