### PR TITLE
Fixes Pairingmodule: Improve PyLongObject handling, optimize, and address Windows/MinGW issues

### DIFF
--- a/charm/core/math/integer/integermodule.h
+++ b/charm/core/math/integer/integermodule.h
@@ -34,6 +34,11 @@
 #define PY_SSIZE_T_CLEAN
 #endif
 
+/* Define MS_WIN64 to get correct PYLONG_BITS_IN_DIGIT on Windows. */
+#if PY_MINOR_VERSION <= 10 && defined(_WIN64) && !defined(MS_WIN64)
+#define MS_WIN64
+#endif
+
 #include <Python.h>
 #include <stdio.h>
 #include <string.h>

--- a/charm/core/math/pairing/miracl/pairingmodule2.h
+++ b/charm/core/math/pairing/miracl/pairingmodule2.h
@@ -39,6 +39,11 @@
 #define PY_SSIZE_T_CLEAN
 #endif
 
+/* Define MS_WIN64 to get correct PYLONG_BITS_IN_DIGIT on Windows. */
+#if PY_MINOR_VERSION <= 10 && defined(_WIN64) && !defined(MS_WIN64)
+#define MS_WIN64
+#endif
+
 #include <Python.h>
 #include <structmember.h>
 #include <longintrepr.h>

--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -35,9 +35,9 @@
   #define PyLongObj_Size(l)  Py_SIZE(l)
 #else
   #define PyLongObj_Val(l, i)  (l)->long_value.ob_digit[i]
-  // #define _PyLong_SIZE_SHIFTS __builtin_popcount(_PyLong_NON_SIZE_BITS)
-  #define _PyLong_SIZE_SHIFTS 2
-  #define PyLongObj_Size(l)  ((l)->long_value.lv_tag >> _PyLong_SIZE_SHIFTS)
+  // lv_tag sign bits: 00 = positive, 01 = zero, 10 = negative
+  #define PyLongObj_Size(l)  ((1 - ((l)->long_value.lv_tag & _PyLong_SIGN_MASK)) \
+							  * ((l)->long_value.lv_tag >> _PyLong_NON_SIZE_BITS))
 #endif
 
 // PEP 674 – Disallow using macros as l-values
@@ -124,7 +124,6 @@ static PyObject *f(PyObject *v, PyObject *w) { \
 	return NULL;				\
 }
 
-// TODO: update these two functions to convert neg numbers
 PyObject *mpzToLongObj (mpz_t m)
 {
 	/* borrowed from gmpy */

--- a/charm/core/math/pairing/pairingmodule.c
+++ b/charm/core/math/pairing/pairingmodule.c
@@ -154,26 +154,17 @@ PyObject *mpzToLongObj (mpz_t m)
 
 void longObjToMPZ (mpz_t m, PyLongObject * p)
 {
-	int size, i, tmp = PyLongObj_Size(p);
+	int size = PyLongObj_Size(p);
 	int isNeg = FALSE;
-	mpz_t temp, temp2;
-	mpz_init (temp);
-	mpz_init (temp2);
-	if (tmp > 0)
-		size = tmp;
-	else {
-		size = -tmp;
+	if (size < 0) {
+		size = -size;
 		isNeg = TRUE;
 	}
 	mpz_set_ui (m, 0);
-	for (i = 0; i < size; i++)
-	{
-		mpz_set_ui (temp, PyLongObj_Val(p, i));
-		mpz_mul_2exp (temp2, temp, PyLong_SHIFT * i);
-		mpz_add (m, m, temp2);
+	for (int i = size - 1; i >= 0; i--) {
+		mpz_mul_2exp (m, m, PyLong_SHIFT);
+		mpz_add_ui (m, m, PyLongObj_Val(p, i));
 	}
-	mpz_clear (temp);
-	mpz_clear (temp2);
 	if(isNeg) mpz_neg(m, m);
 }
 

--- a/charm/core/math/pairing/pairingmodule.h
+++ b/charm/core/math/pairing/pairingmodule.h
@@ -34,6 +34,11 @@
 #define PY_SSIZE_T_CLEAN
 #endif
 
+/* Define MS_WIN64 to get correct PYLONG_BITS_IN_DIGIT on Windows. */
+#if PY_MINOR_VERSION <= 10 && defined(_WIN32) && !defined(MS_WIN64)
+  #define MS_WIN64
+#endif
+
 #include <Python.h>
 #include <structmember.h>
 

--- a/charm/core/math/pairing/pairingmodule.h
+++ b/charm/core/math/pairing/pairingmodule.h
@@ -78,8 +78,10 @@ typedef enum Group GroupType;
 
 #ifdef DEBUG
 #define debug_e(...)	element_printf("DEBUG: "__VA_ARGS__)
+#define debug_gmp(...)	gmp_printf("DEBUG: "__VA_ARGS__)
 #else
 #define debug_e(...)
+#define debug_gmp(...)
 #endif
 
 #define PrintPyRef(msg, o) printf("%s:" #msg " ref cnt = '%i'\n", __FUNCTION__, (int) Py_REFCNT(o));

--- a/charm/core/math/pairing/relic/pairingmodule3.h
+++ b/charm/core/math/pairing/relic/pairingmodule3.h
@@ -34,6 +34,11 @@
 #define PY_SSIZE_T_CLEAN
 #endif
 
+/* Define MS_WIN64 to get correct PYLONG_BITS_IN_DIGIT on Windows. */
+#if PY_MINOR_VERSION <= 10 && defined(_WIN64) && !defined(MS_WIN64)
+#define MS_WIN64
+#endif
+
 #include <Python.h>
 #include <structmember.h>
 #include <longintrepr.h>


### PR DESCRIPTION
This Pull Request introduces several improvements and fixes to the pairing module.

**Problem Background:**

Upon further testing, I discovered that my previous attempt in #328 did not fully resolve the underlying issues. I've created a simple test script, `test.py`, that exposes several lingering problems:

```Python
from charm.toolbox.pairinggroup import PairingGroup, G1, G2, GT, ZR, pair, pc_element as Element

group = PairingGroup("MNT159")
print("********************** PairingGroup ZR Test **********************")
m = group.order()
print("m(Z):\t", m)

r1 = group.random(ZR)
print("r1(ZR):\t", r1)
print("0*ZR:\t", 0 * r1)
print("1*ZR:\t", 1 * r1)

r2 = group.random(ZR)
print("r2(ZR):\t", r2)
print("ZR^2:\t", r1 * r2)
print("Z*ZR:\t", int(r1) * r2)
print("ZR*Z:\t", r1 * int(r2))
print("Z^2mod:\t", int(r1) * int(r2) % m)

a = group.init(ZR, 1)
print("a(ZR):\t", a)
b = group.init(ZR, -1)
print("b(ZR):\t", b)
c = group.init(ZR, m + 123456789)
print("c(ZR):\t", c)
d = group.init(ZR, -m - 123456789)
print("d(ZR):\t", d)
r3 = group.init(ZR, int(r1 * m + r2))
print("r3(ZR):\t", r3)
print("r2 = r3:", r2 == r3)

print("*****************************************************************")
```
**Key Contributions in this PR:**

1.  **Refined `PyLongObject` Size Handling & Macro Naming:**
    * **Problem:** The `PyLongObj_Size` and `Py_SET_SIZE` macros, crucial for correctly getting/setting the signed length of the `PyLongObject`'s `ob_digit` array, had incorrect logic, affecting Python 3.12+ environments. This can be demonstrated by `b = group.init(ZR, -1)` and `m = group.order()` respectively.
    * **Solution:** The logic for `PyLongObj_Size` and `Py_SET_SIZE` has been refined to better interpret the `lv_tag` field and extract the signed length. All related macros have been consistently renamed (e.g., `PyLongObj_Sizel` to `PyLong_SIZE`) for better readability.
    * **NOTE:** Everything seems normal now but **MORE TESTS ARE NEEDED**. Furthermore, the `lv_tag` field, which these macros interact with, appears to be an internal CPython design. Making reliance on its specific bit-level interpretation might be unstable (Python 3.14+ may introduce new C APIs per [PEP 757](https://peps.python.org/pep-0757/)).

2.  **Fixed incorrect `PyLong_SHIFT` when compiled with MinGW for Windows 64-bit System:**
    * **Problem:** On Windows 64-bit systems, when compiled with MinGW and run with Python 3.10 and below, the `PyLong_SHIFT` value was erroneously set to 15 bits, leading to incorrect `longObjToMPZ` behavior with very large integers. This can be demonstrated by `c = group.init(ZR, m + 123456789)` or `d = group.init(ZR, -m - 123456789)`.
    * **Solution:** We defined the `MS_WIN64` macro in the relevant header files, which sets `SIZEOF_VOID_P` to 8 in `<your_python>/include/pyconfig.h`, which further ensures `PYLONG_BITS_IN_DIGIT` is set to 30 in `<your_python>/include/pyport.h`, leading to the correct `PyLong_SHIFT` value.

3.  **Enhanced `Element_mul` for Larger Integer Support:**
    * **Problem:** In the `Element_mul` function, the variable `z` was limited to a `signed long int` type. This restricted its ability to process larger integer inputs, potentially causing overflows for certain operations. This can be demonstrated by `print("Z*ZR:\t", int(r1) * r2)` or `print("ZR*Z:\t", r1 * int(r2))`.
    * **Solution:** The type of  `z`  has been changed from `signed long int` to `mpz_t`. This allows the function to handle arbitrary-precision integers, expanding its capability to process much larger inputs without limitation.

4.  **Optimized `longObjToMPZ` Performance:**
    *  The implementation of `longObjToMPZ` has been fine-tuned to eliminate redundant `mpz` related operations.